### PR TITLE
Python 3 compatibility and support for default values in docker_link

### DIFF
--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -1,4 +1,4 @@
-import os, sys
+import io, os, sys
 import argparse
 
 import jinja2
@@ -22,7 +22,7 @@ class FilePathLoader(jinja2.BaseLoader):
 
         # Read
         try:
-            with open(template, 'r') as f:
+            with io.open(template, 'rb') as f:
                 contents = f.read().decode(self.encoding)
         except IOError:
             raise jinja2.TemplateNotFound(template)
@@ -123,4 +123,5 @@ def main():
         sys.stdin,
         sys.argv[1:]
     )
-    sys.stdout.write(output)
+    outstream = getattr(sys.stdout, 'buffer', sys.stdout)
+    outstream.write(output)

--- a/j2cli/context.py
+++ b/j2cli/context.py
@@ -1,5 +1,11 @@
 import sys
 
+# Patch basestring in for python 3 compat
+try:
+    basestring
+except NameError:
+    basestring = str
+
 #region Parsers
 
 def _parse_ini(data_string):

--- a/j2cli/context.py
+++ b/j2cli/context.py
@@ -114,10 +114,10 @@ def _parse_env(data_string):
         data = filter(
             lambda l: len(l) == 2 ,
             (
-                map(
+                list(map(
                     str.strip,
                     line.split('=')
-                )
+                ))
                 for line in data_string.split("\n"))
         )
     else:

--- a/j2cli/context.py
+++ b/j2cli/context.py
@@ -25,7 +25,7 @@ def _parse_ini(data_string):
         $ j2 config.j2 data.ini
         $ cat data.ini | j2 --format=ini config.j2
     """
-    from io import BytesIO
+    from io import StringIO
 
     # Override
     class MyConfigParser(ConfigParser.ConfigParser):
@@ -41,7 +41,7 @@ def _parse_ini(data_string):
 
     # Parse
     ini = MyConfigParser()
-    ini.readfp(BytesIO(data_string))
+    ini.readfp(ini_file_io(data_string))
 
     # Export
     return ini.as_dict()
@@ -152,8 +152,10 @@ except ImportError:
 # INI: Python 2 | Python 3
 try:
     import ConfigParser
+    from io import BytesIO as ini_file_io
 except ImportError:
     import configparser as ConfigParser
+    from io import StringIO as ini_file_io
 
 # YAML
 try:

--- a/j2cli/extras/filters.py
+++ b/j2cli/extras/filters.py
@@ -1,5 +1,6 @@
 """ Custom Jinja2 filters """
 
+from jinja2 import is_undefined
 import re
 
 
@@ -28,6 +29,10 @@ def docker_link(value, format='{addr}:{port}'):
     :param format: The format to apply. Supported placeholders: `{proto}`, `{addr}`, `{port}`
     :return: Formatted string
     """
+    # pass undefined values on down the pipeline
+    if(is_undefined(value)):
+        return value
+
     # Parse the value
     m = re.match(r'(?P<proto>.+)://' r'(?P<addr>.+):' r'(?P<port>.+)$', value)
     if not m:

--- a/tests/render-test.py
+++ b/tests/render-test.py
@@ -23,8 +23,11 @@ class RenderTest(unittest.TestCase):
 
     def _testme(self, argv, stdin=None, env=None):
         """ Helper test shortcut """
-        self.assertEqual(self.expected_output,
-                         render_command(os.getcwd(), env or {}, stdin, argv))
+        result = render_command(os.getcwd(), env or {}, stdin, argv)
+        if(isinstance(result, str)):
+            self.assertEqual(self.expected_output, result)
+        else:
+            self.assertEqual(self.expected_output.encode('UTF-8'), result)
 
     def test_ini(self):
         # Filename


### PR DESCRIPTION
Hi,

I've patched docker_link to return undefined if the env variable isn't set, that way you can use:

```
foo:
    host: {{ FOO_PORT | docker_link('{addr}') | default('localhost') }}
```

I've also made some changes to run on python 3.4:
- use io.open in bytes mode so that Python 3 doesn't choke on file.read().decode()
- use stdout.buffer when writing in python 3
- set basestring = str if it doesn't exist so that `isinstance(foo, basestring)` works. Hacky, but minimally invasive.
- when parsing ini files, use StringIO for Python 3, we do this by importing either BytesIO or StringIO as ini_file_io.
- unit tests check to see if the output is a bytestring or a string, and compare appropriately.

I'm not a Python programmer, so if I've done something dumb, let me know and I'll fix it up.

 -- B
