### PR TITLE
READY FOR REVIEW - Quick fix for #5. Experimental support for Python 3.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: python
+python: 3.5
 install:
   - pip install tox
 script:
-  - tox
+  - tox -e "${TOXENV}"
 env:
   - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=py35
+  - TOXENV=pypy

--- a/j2cli/__init__.py
+++ b/j2cli/__init__.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 """ j2cli main file """
+from __future__ import unicode_literals
 import pkg_resources
 
 __author__ = "Mark Vartanyan"

--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+from io import open # pylint: disable=redefined-builtin
 import os, sys
 import argparse
 
@@ -22,8 +24,8 @@ class FilePathLoader(jinja2.BaseLoader):
 
         # Read
         try:
-            with open(template, 'r') as f:
-                contents = f.read().decode(self.encoding)
+            with open(template, 'rt', encoding=self.encoding) as f:
+                contents = f.read()
         except IOError:
             raise jinja2.TemplateNotFound(template)
 
@@ -51,8 +53,7 @@ def render_template(cwd, template_path, context):
 
     return env \
         .get_template(template_path) \
-        .render(context) \
-        .encode('utf-8')
+        .render(context)
 
 
 def render_command(cwd, environ, stdin, argv):
@@ -98,7 +99,8 @@ def render_command(cwd, environ, stdin, argv):
     if args.data == '-' and args.format == 'env':
         input_data_f = None
     else:
-        input_data_f = stdin if args.data == '-' else open(args.data)
+        # Warning: assumes utf-8 for input file encoding
+        input_data_f = stdin if args.data == '-' else open(args.data, encoding="utf-8")
 
     # Read data
     context = read_context_data(

--- a/j2cli/context.py
+++ b/j2cli/context.py
@@ -1,4 +1,16 @@
-import sys
+from __future__ import unicode_literals
+
+try:
+    basestring # pylint: disable=pointless-statement
+    strip = unicode.strip
+except NameError:
+    basestring = str # pylint: disable=redefined-builtin
+    strip = str.strip
+
+try:
+    import itertools.imap as map # pylint: disable=redefined-builtin
+except ImportError:
+    pass
 
 #region Parsers
 
@@ -19,7 +31,7 @@ def _parse_ini(data_string):
         $ j2 config.j2 data.ini
         $ cat data.ini | j2 --format=ini config.j2
     """
-    from io import BytesIO
+    from io import StringIO
 
     # Override
     class MyConfigParser(ConfigParser.ConfigParser):
@@ -35,7 +47,7 @@ def _parse_ini(data_string):
 
     # Parse
     ini = MyConfigParser()
-    ini.readfp(BytesIO(data_string))
+    ini.readfp(StringIO(data_string))
 
     # Export
     return ini.as_dict()
@@ -108,11 +120,12 @@ def _parse_env(data_string):
         data = filter(
             lambda l: len(l) == 2 ,
             (
-                map(
-                    str.strip,
+                list(map(
+                    strip,
                     line.split('=')
-                )
-                for line in data_string.split("\n"))
+                ))
+                for line in data_string.split("\n")
+            )
         )
     else:
         data = data_string

--- a/j2cli/extras/__init__.py
+++ b/j2cli/extras/__init__.py
@@ -1,1 +1,2 @@
+from __future__ import unicode_literals
 from . import filters

--- a/j2cli/extras/filters.py
+++ b/j2cli/extras/filters.py
@@ -1,5 +1,5 @@
 """ Custom Jinja2 filters """
-
+from __future__ import unicode_literals
 import re
 
 

--- a/tests/render-test.py
+++ b/tests/render-test.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+from io import open # pylint: disable=redefined-builtin
 import unittest
 import os.path
 
@@ -32,7 +34,7 @@ class RenderTest(unittest.TestCase):
         # Format
         self._testme(['--format=ini', 'resources/nginx.j2', 'resources/data.ini'])
         # Stdin
-        self._testme(['--format=ini', 'resources/nginx.j2'], stdin=open('resources/data.ini'))
+        self._testme(['--format=ini', 'resources/nginx.j2'], stdin=open('resources/data.ini', encoding='utf-8'))
 
     def test_json(self):
         # Filename
@@ -40,7 +42,7 @@ class RenderTest(unittest.TestCase):
         # Format
         self._testme(['--format=json', 'resources/nginx.j2', 'resources/data.json'])
         # Stdin
-        self._testme(['--format=json', 'resources/nginx.j2'], stdin=open('resources/data.json'))
+        self._testme(['--format=json', 'resources/nginx.j2'], stdin=open('resources/data.json', encoding='utf-8'))
 
     def test_yaml(self):
         try:
@@ -54,7 +56,7 @@ class RenderTest(unittest.TestCase):
         # Format
         self._testme(['--format=yaml', 'resources/nginx.j2', 'resources/data.yml'])
         # Stdin
-        self._testme(['--format=yaml', 'resources/nginx.j2'], stdin=open('resources/data.yml'))
+        self._testme(['--format=yaml', 'resources/nginx.j2'], stdin=open('resources/data.yml', encoding='utf-8'))
 
     def test_env(self):
         # Filename

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27
+envlist=py27,py33,py34,py35,pypy
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
You'll probably want to look this over carefully. I think most of the changes are pretty straightforward, but this PR includes an explicit assumption that input files are UTF-8 (or a subset). This may have been an implicit requirement already.

(tagging #5)
