### PR TITLE
Keep trailing newline

### DIFF
--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -43,7 +43,8 @@ def render_template(cwd, template_path, context):
     """
     env = jinja2.Environment(
         loader=FilePathLoader(cwd),
-        undefined=jinja2.StrictUndefined # raises errors for undefined variables
+        undefined=jinja2.StrictUndefined, # raises errors for undefined variables
+        keep_trailing_newline=True
     )
 
     # Register extras

--- a/tests/render-test.py
+++ b/tests/render-test.py
@@ -19,7 +19,8 @@ class RenderTest(unittest.TestCase):
 
   access_log /var/log/nginx//http.access.log combined;
   error_log  /var/log/nginx//http.error.log;
-}"""
+}
+"""
 
     def _testme(self, argv, stdin=None, env=None):
         """ Helper test shortcut """


### PR DESCRIPTION
Configures Jinja2 to keep a trailing newline when rendering templates. Removing those causes some really subtle problems with certain config files, e.g. ssmtp.conf just ignores the last line if the trailing newline is missing.
