### PR TITLE
Support for loading custom jinja2 filters + overriding behaviour for undefined variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,24 @@ Or even read environment variables from a file:
 * `template`: Jinja2 template file to render
 * `data`: (optional) path to the data used for rendering. The default is `-`: use stdin
 
-Options:
+Options and flags:
 
 * `--format, -f`: format for the data file. The default is `?`: guess from file extension.
+* `--custom-filters, -C`: Load custom Jinja2 filters and tests from `jinja2_custom` module in the current directory.
+
+    The filters and tests to be loaded must be listed in two dictionaries,
+    named  `FILTERS` and `TESTS` respectively. E.g.:
+
+```python
+   def comment(t):
+      return '# '+t
+
+   def is_odd(n):
+      return True if (n % 2) else False
+
+   FILTERS = {'comment': comment,}
+   TESTS = {'is_odd': is_odd,}
+```
 
 There is some special behavior with environment variables:
 

--- a/README.rst
+++ b/README.rst
@@ -77,10 +77,26 @@ Reference
 -  ``data``: (optional) path to the data used for rendering. The default
    is ``-``: use stdin
 
-Options:
+Options and flags:
 
 -  ``--format, -f``: format for the data file. The default is ``?``:
    guess from file extension.
+-  ``--custom-filters, -C``: Load custom Jinja2 filters and tests from
+   ``jinja2_custom`` module in the current directory.
+
+   The filters and tests to be loaded must be listed in two
+   dictionaries, named ``FILTERS`` and ``TESTS`` respectively. E.g.:
+
+.. code:: python
+
+       def comment(t):
+          return '# '+t
+
+       def is_odd(n):
+          return True if (n % 2) else False
+
+       FILTERS = {'comment': comment,}
+       TESTS = {'is_odd': is_odd,}
 
 There is some special behavior with environment variables:
 

--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -157,5 +157,9 @@ def main():
         sys.stdin,
         sys.argv[1:]
     )
-    sys.stdout = sys.stdout.detach()
+    try:
+        # python3
+        sys.stdout = sys.stdout.detach()
+    except:
+        pass
     sys.stdout.write(output)

--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -23,7 +23,7 @@ class FilePathLoader(jinja2.BaseLoader):
 
         # Read
         try:
-            with open(template, 'r') as f:
+            with open(template, 'rb') as f:
                 contents = f.read().decode(self.encoding)
         except IOError:
             raise jinja2.TemplateNotFound(template)
@@ -155,4 +155,5 @@ def main():
         sys.stdin,
         sys.argv[1:]
     )
+    sys.stdout = sys.stdout.detach()
     sys.stdout.write(output)

--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -54,6 +54,8 @@ def render_template(cwd, template_path, context, undefined='strict', custom_filt
     env = jinja2.Environment(
         loader=FilePathLoader(cwd),
         extensions=['jinja2.ext.with_', 'jinja2.ext.do', 'jinja2.ext.loopcontrols', ],
+        trim_blocks=True,
+        lstrip_blocks=True,
         undefined=undefined_opts[undefined],
     )
 

--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -53,7 +53,7 @@ def render_template(cwd, template_path, context, undefined='strict', custom_filt
     }
     env = jinja2.Environment(
         loader=FilePathLoader(cwd),
-        extensions=['jinja2.ext.with_', 'jinja2.ext.do', ],
+        extensions=['jinja2.ext.with_', 'jinja2.ext.do', 'jinja2.ext.loopcontrols', ],
         undefined=undefined_opts[undefined],
     )
 

--- a/misc/_doc/README.md.j2
+++ b/misc/_doc/README.md.j2
@@ -58,9 +58,24 @@ Or even read environment variables from a file:
 * `template`: Jinja2 template file to render
 * `data`: (optional) path to the data used for rendering. The default is `-`: use stdin
 
-Options:
+Options and flags:
 
 * `--format, -f`: format for the data file. The default is `?`: guess from file extension.
+* `--custom-filters, -C`: Load custom Jinja2 filters and tests from `jinja2_custom` module in the current directory.
+
+    The filters and tests to be loaded must be listed in two dictionaries,
+    named  `FILTERS` and `TESTS` respectively. E.g.:
+
+```python
+   def comment(t):
+      return '# '+t
+
+   def is_odd(n):
+      return True if (n % 2) else False
+
+   FILTERS = {'comment': comment,}
+   TESTS = {'is_odd': is_odd,}
+```
 
 There is some special behavior with environment variables:
 


### PR DESCRIPTION
Added new flag '-C'. If enabled, will attempt to read additional jinja filters from current directory.
Added new flag '--undefined'. Depending on the value, the undefined variables are treated differently during rendering.
