### PR TITLE
Add snap packaging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/kolypto/j2cli.svg)](https://travis-ci.org/kolypto/j2cli)
+[![Build Status](https://travis-ci.org/kolypto/j2cli.svg)](https://travis-ci.org/kolypto/j2cli) [![Snap Status](https://build.snapcraft.io/badge/cmars/j2cli.svg)](https://build.snapcraft.io/user/cmars/j2cli)
 
 j2cli - Jinja2 Command-Line Tool
 ================================

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: j2
+version: 0.3.1-0
+summary: Command-line interface to Jinja2 for templating in shell scripts.
+description: |
+  Command-line interface to [Jinja2](http://jinja.pocoo.org/docs/) for templating in shell scripts.
+  
+  Features:
+  
+  Jinja2 templating
+  Allows to use environment variables! Hello [Docker](http://www.docker.com/) :)
+  INI, YAML, JSON data sources supported
+  Inspired by [mattrobenolt/jinja2-cli](https://github.com/mattrobenolt/jinja2-cli)
+
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict # use 'strict' once you have the right plugs and slots
+
+apps:
+    j2:
+        command: bin/j2
+        plugs:
+            - home
+
+parts:
+    pip:
+        plugin: python2
+        source: https://github.com/kolypto/j2cli.git
+        source-tag: v0.3.1
+        requirements: requirements.txt


### PR DESCRIPTION
This adds [snap](https://snapcraft.io) packaging for j2. On Ubuntu 16.04, for example:

`snap install j2` to install j2cli.

If you'd like to build the snap, use `snapcraft`.

I've published this for now because I find it useful, but if you'd like to take over packaging, let me know, I'd be happy to arrange for this.
