### PR TITLE
Support python 2.6.

### DIFF
--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -74,7 +74,7 @@ def render_command(cwd, environ, stdin, argv):
         epilog=''
     )
     parser.add_argument('-v', '--version', action='version',
-                        version='j2cli {}, Jinja2 {}'.format(__version__, jinja2.__version__))
+                        version='j2cli {0}, Jinja2 {1}'.format(__version__, jinja2.__version__))
 
     parser.add_argument('-f', '--format', default='?', help='Input data format', choices=['?'] + list(FORMATS.keys()))
     parser.add_argument('template', help='Template file to process')

--- a/j2cli/context.py
+++ b/j2cli/context.py
@@ -177,5 +177,5 @@ def read_context_data(format, f, environ):
 
     # Parse it
     if format not in FORMATS:
-        raise ValueError('{} format unavailable'.format(format))
+        raise ValueError('{0} format unavailable'.format(format))
     return FORMATS[format](data_string)

--- a/j2cli/extras/filters.py
+++ b/j2cli/extras/filters.py
@@ -31,7 +31,7 @@ def docker_link(value, format='{addr}:{port}'):
     # Parse the value
     m = re.match(r'(?P<proto>.+)://' r'(?P<addr>.+):' r'(?P<port>.+)$', value)
     if not m:
-        raise ValueError('The provided value does not seems to be a Docker link: {}'.format(value))
+        raise ValueError('The provided value does not seems to be a Docker link: {0}'.format(value))
     d = m.groupdict()
 
     # Format


### PR DESCRIPTION
Thanks for this great tool.

When I run it with Python 2.6 I get this error: "ValueError: zero length field name in format."

It looks like the ability to omit positional arguments was introduced only in Python 3.1: "The positional argument specifiers can be omitted, so '{} {}' is equivalent to '{0} {1}'." (https://docs.python.org/dev/library/string.html#format-string-syntax)

Any chance we can update the tool to be compatible with Python 2.6 ?