### PR TITLE
fix UTF-8 bug with env vars which are myvar=Jürgen

### DIFF
--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -1,6 +1,9 @@
 import os, sys
 import argparse
 
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
 import jinja2
 import jinja2.loaders
 from . import __version__


### PR DESCRIPTION
fix UTF-8 bug with env vars which are myvar=Jürgen.

see https://github.com/kolypto/j2cli/issues/17

Example:

```
$ cat /tmp/template.j2
Please welcome myfriend {{ friendname }} !
$ export friendname="Jürgen"
$ j2 /tmp/template.j2
Please welcome myfriend Jürgen !
```

Without this fix, you end up with an ascii error:

```
$ j2 /tmp/template.j2
Traceback (most recent call last):
  File "/usr/bin/j2", line 9, in <module>
    load_entry_point('j2cli==0.3.1-0', 'console_scripts', 'j2')()
  File "/usr/lib/python2.7/site-packages/j2cli-0.3.1_0-py2.7.egg/j2cli/cli.py", line 124, in main
    sys.argv[1:]
  File "/usr/lib/python2.7/site-packages/j2cli-0.3.1_0-py2.7.egg/j2cli/cli.py", line 114, in render_command
    context
  File "/usr/lib/python2.7/site-packages/j2cli-0.3.1_0-py2.7.egg/j2cli/cli.py", line 54, in render_template
    .render(context) \
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 969, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 742, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/tmp/template.j2", line 1, in top-level template code
    Please welcome myfriend {{ friendname }} !
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1: ordinal not in range(128)
```