### PR TITLE
Add --environment-config param

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ Options:
     (This will overwrite any existing variables!)
 * `-o outfile`: Write rendered template to a file
 * `--undefined`: Allow undefined variables to be used in templates (no error will be raised)
+* `--environment-config`: Provide a config file (format guessed from file
+  extension) containing key/value pairs that can be passed to Jinja2's
+  [Environment
+  configuration](http://jinja.pocoo.org/docs/2.10/api/#jinja2.Environment). This
+  can be handy for tweaking the way your templates are processed by Jinja2, for
+  example providing a YAML file with "lstrip_blocks: true" can configure Jinja2
+  to produce less whitespace in the output.
 
 * `--filters filters.py`: Load custom Jinja2 filters and tests from a Python file.
     Will load all top-level functions and register them as filters.

--- a/j2cli/context.py
+++ b/j2cli/context.py
@@ -175,7 +175,7 @@ except ImportError:
 
 
 
-def read_context_data(format, f, environ, import_env=None):
+def read_context_data(format, f, environ=None, import_env=None):
     """ Read context data into a dictionary
     :param format: Data format
     :type format: str


### PR DESCRIPTION
Basically, I wanted to set lstrip_blocks and trim_blocks to true when using
j2cli. I didn't see a way to do that, so this is a generic way to achieve it.
You can now pass a config file which use kwargs-expanded and passed to the
jinja2 Environment. This allows the user to break things confusingly, but if
they are using this feature, presumably they already understand jinja2 well
enough to debug the problem for themself.