### PR TITLE
Fix not being able to use the env format with stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ NGINX_LOGS=/var/log/nginx/
 And render with:
 
     $ j2 config.j2 data.env
-    $ env | j2 --format=env config.j2.
+    $ env | j2 --format=env config.j2
 
 This is especially useful with Docker to link containers together.
 

--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -138,7 +138,7 @@ def render_command(cwd, environ, stdin, argv):
             }[os.path.splitext(args.data)[1]]
 
     # Input: data
-    if args.data == '-' and args.format == 'env':
+    if args.data == '-' and args.format == 'env' and (stdin is None or stdin.isatty()):
         input_data_f = None
     else:
         input_data_f = stdin if args.data == '-' else open(args.data)

--- a/j2cli/context.py
+++ b/j2cli/context.py
@@ -113,7 +113,7 @@ def _parse_env(data_string):
     And render with:
 
         $ j2 config.j2 data.env
-        $ env | j2 --format=env config.j2.
+        $ env | j2 --format=env config.j2
 
     This is especially useful with Docker to link containers together.
     """

--- a/tests/render-test.py
+++ b/tests/render-test.py
@@ -98,6 +98,8 @@ class RenderTest(unittest.TestCase):
         self._testme_std(['resources/nginx-env.j2', 'resources/data.env'])
         # Format
         self._testme_std(['--format=env', 'resources/nginx-env.j2', 'resources/data.env'])
+        # Stdin
+        self._testme_std(['--format=env', 'resources/nginx-env.j2'], stdin=open('resources/data.env'))
 
         # Environment!
         env = dict(NGINX_HOSTNAME='localhost', NGINX_WEBROOT='/var/www/project', NGINX_LOGS='/var/log/nginx/')


### PR DESCRIPTION
## The problem

You can't use the env format in combination with stdin

```bash
# example 1
$ cat data.env | j2 template.yml.j2
# example 2
$ j2 template.yml.j2 < data.env
# both produce a stacktrace like this:
# ...
jinja2.exceptions.UndefinedError: 'IP_ADDRESS' is undefined
```
### Example files

data.env
```env
IP_ADDRESS=127.0.0.1
```

template.yml.j2
```yaml
host:
  ip: {{ IP_ADDRESS }}
```
## What I did

I added a unit test for the format env that uses stdin (which fails) and fixed the problem by checking if the stdin is [connected to a shell like environment](https://docs.python.org/3/library/os.html#os.isatty) and if thats not the case (for instance when data is piped into the command) to use the regular code that would handle stdin.