### PR TITLE
Enable  by default

### DIFF
--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -122,7 +122,8 @@ def render_command(cwd, environ, stdin, argv):
                         help='A Python file that implements hooks to fine-tune the j2cli behavior')
     parser.add_argument('--no-compact', action='store_true', dest='no_compact',
                         help='Do not compact space around Jinja2 blocks.')
-    parser.add_argument('--undefined', action='store_true', dest='undefined', help='Allow undefined variables to be used in templates (no error will be raised)')
+    parser.add_argument('-U', '--undefined', action='store_true', dest='undefined',
+                        help='Allow undefined variables to be used in templates (no error will be raised.)')
     parser.add_argument('-o', metavar='outfile', dest='output_file', help="Output to a file instead of stdout")
     parser.add_argument('template', help='Template file to process')
     parser.add_argument('data', nargs='?', default=None, help='Input data file path; "-" to use stdin')

--- a/j2cli/context.py
+++ b/j2cli/context.py
@@ -1,10 +1,5 @@
+import six
 import sys
-
-# Patch basestring in for python 3 compat
-try:
-    basestring
-except NameError:
-    basestring = str
 
 #region Parsers
 
@@ -120,7 +115,7 @@ def _parse_env(data_string):
         $ j2 config.j2 - < data.env
     """
     # Parse
-    if isinstance(data_string, basestring):
+    if isinstance(data_string, six.string_types):
         data = filter(
             lambda l: len(l) == 2 ,
             (

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 wheel
 nose
 exdoc
+six

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
 
     install_requires=[
         'jinja2 >= 2.7.2',
+        'six >= 1.10',
     ],
     extras_require={
         'yaml': [pyyaml_version,]


### PR DESCRIPTION
This patch turns on [Jinja2 whitespace control]( http://jinja.pocoo.org/docs/2.10/templates/#whitespace-control) by default. This will greatly reduce the need to use manual whitespace control in the templates in order to produce good looking output.

**Rationale:**
_Jinja2 on the web:_ The common use of Jinja2 is to serve web requests in realtime. The rendered templates are rarely inspected by a human and have a lifetime of a few minutes (at best). In this context, it is reasonable to turn off whitespace control to save some processing time and maximize throughput.
_Jinja2 on j2cli:_ j2cli is meant mostly as a batch processing tool. I.e. it is invoked only periodically. The  generated output persists for much longer, and it is quite likely to be inspected by a human. Therefore, enabling whitespace control by default to produce better looking output makes
sense.

**Side-effects:**
There are _barely any side-effects_ from this patch. Where manual space control is used in templates (e.g. `{%- ... -%}`) the `-` modifiers will become redundant. They can be eventually removed at a time of convenience. 
The only side-effect I've noticed is the case of consecutive `{% include ... %}` tags. In this case, whitespace control needs to be manually disabled using the `+` modifier. E.g. this:
```
{% include 'include/a.inc' %}
{% include 'include/a.inc' %}
```
becomes:
```
{%+ include 'include/a.inc' %}
{%+ include 'include/a.inc' %}
```

**But I love whitespace in my output:**
In case someone absolutely hates this behaviour, it can be turned off with the new ` --no-compact` flag.