### PR TITLE
Set maximum version for jinja requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/kolypto/j2cli.svg)](https://travis-ci.org/kolypto/j2cli)
-[![Pythons](https://img.shields.io/badge/python-2.6%20%7C%202.7%20%7C%203.4%E2%80%933.7%20%7C%20pypy-blue.svg)](.travis.yml)
+[![Pythons](https://img.shields.io/badge/python-2.7%20%7C%203.5%E2%80%933.7%20%7C%20pypy-blue.svg)](.travis.yml)
 
 j2cli - Jinja2 Command-Line Tool
 ================================

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     },
 
     install_requires=[
-        'jinja2 >= 2.7.2',
+        'jinja2 >= 2.7.2,<3.0.0',
     ],
     extras_require={
         'yaml': [pyyaml_version,]


### PR DESCRIPTION
Without a max version set for jinja, it now gets jinja 3.0.0, which dropped support for python 2.7 and 3.5, causing a BC break on any tag up until now using these versions.

Adding this version here allows the latest version to still support these, but also means it should be considered to have future versions of j2cli not support these versions of python if it is not necessary anymore by choice..

Fixes #53 